### PR TITLE
Use empty data for SList

### DIFF
--- a/src/Data/Undefined/NoProblem.purs
+++ b/src/Data/Undefined/NoProblem.purs
@@ -79,7 +79,7 @@ infixr 2 type Beside as <>
 infixr 1 type Above as |>
 
 -- | Ripped from record-extra
-foreign import kind SList
+data SList
 
 foreign import data SCons ∷ Symbol → SList → SList
 


### PR DESCRIPTION
> Foreign kind imports are deprecated and will be removed in a future release. Use empty 'data' instead.