### PR TITLE
Restore monomorphic use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ There is really no difference in the API provided by this module so we have `Coe
 
 #### Pros
 
-When you reach for this type of coercing you can expect a better behavior in the case of polymorphic values. The previous example ~works~ **should work** (there is a discussion around that regression in [this PS compiler issue](https://github.com/purescript/purescript/issues/4338)) now without annotation for the array in `x` prop:
+When you reach for this type of coercing you can expect a better behavior in the case of polymorphic values. The previous example works now without annotation for the array in `x` prop:
 
 ```purescript
 closedCoerceArray ∷ Effect Unit
@@ -166,7 +166,7 @@ closedCoerceArray = do
   let
     -- We hope that this annotation is temporary and could be dropped when the PS constraint
     -- solver issue mentioned above is solved.
-    argument = { x: [] :: Array Int }
+    argument = { x: [] }
 
     r = (Closed.coerce argument :: OptionsWithArrayValue)
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -5,6 +5,7 @@
   , "effect"
   , "either"
   , "foreign"
+  , "identity"
   , "maybe"
   , "newtype"
   , "prelude"

--- a/src/Data/Undefined/NoProblem/Closed.purs
+++ b/src/Data/Undefined/NoProblem/Closed.purs
@@ -68,8 +68,6 @@ class CoerceProp (given :: Type) (expected :: Type) (debugPath ∷ SList) | expe
 instance coercePropReq ∷
   (TypeEqualsOnPath a b p) ⇒
   CoerceProp a (Req b) p
-else instance coercePropOptValueMatch ∷
-  CoerceProp a (Opt a) p
 else instance coercePropOptValuesMatch ∷
   CoerceProp (Opt a) (Opt a) p
 else instance coercePropOptValues ∷

--- a/src/Data/Undefined/NoProblem/Open.purs
+++ b/src/Data/Undefined/NoProblem/Open.purs
@@ -72,8 +72,6 @@ class CoerceProp (given :: Type) (expected :: Type) (debugPath ∷ SList) | expe
 instance coercePropReq
   ∷ (TypeEquals a b)
   ⇒ CoerceProp a (Req b) p
-else instance coercePropOptValueMatch
-  :: CoerceProp a (Opt a) p
 else instance coercePropOptValuesMatch
   :: CoerceProp (Opt a) (Opt a) p
 else instance coercePropOptValues

--- a/test/PolymorphicFields.purs
+++ b/test/PolymorphicFields.purs
@@ -3,6 +3,7 @@ module Test.PolymorphicFields where
 import Prelude
 
 import Data.Array (catMaybes)
+import Data.Identity (Identity)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
 import Data.Undefined.NoProblem (Opt, Req(..), opt, toMaybe)
@@ -10,6 +11,7 @@ import Data.Undefined.NoProblem.Closed as Closed
 import Data.Undefined.NoProblem.Open as Open
 import Effect (Effect)
 import Test.Assert (assert)
+import Type.Proxy (Proxy(..))
 
 type Args a = { x :: Req a, y :: Opt a, z :: Int }
 
@@ -24,10 +26,20 @@ openConsumer args' = show $ catMaybes [Just (unwrap args.x), toMaybe args.y]
     args = Open.coerce args' :: Args a
 
 nestedClosedConsumer :: forall a. Show a => a -> String
-nestedClosedConsumer a = closedConsumer { x: a, y: a, z: 42 } <> closedConsumer { x: a, y: opt a, z: 42 }
+nestedClosedConsumer a = closedConsumer { x: a, y: opt a, z: 42 }
 
 nestedOpenConsumer :: forall a. Show a => a -> String
-nestedOpenConsumer a = openConsumer { x: a, y: a, z: 42 } <> openConsumer { x: a, y: opt a, z: 42 }
+nestedOpenConsumer a = openConsumer { x: a, y: opt a, z: 42 }
+
+monoConsumer :: forall args. Closed.Coerce args (Args Int) => args -> String
+monoConsumer args' = closedConsumer { x: unwrap args.x, y: args.y, z: args.z }
+  where
+    args = Closed.coerce args' :: Args Int
+
+monoAmbiguousConsumer :: forall args. Closed.Coerce args (Args (Maybe Int)) => args -> String
+monoAmbiguousConsumer args' = closedConsumer { x: unwrap args.x, y: args.y, z: args.z }
+  where
+    args = Closed.coerce args' :: Args (Maybe Int)
 
 test :: Effect Unit
 test = do
@@ -43,6 +55,8 @@ test = do
     closedConsumer { x: true, y: false, z: 42 } == show [true, false]
   assert $ -- Make sure explicitly wrapping the field in `Req` also works
     closedConsumer { x: Req 5, z: 42 } == show [5]
+  assert $
+    nestedClosedConsumer 42 == show [42, 42]
 
   assert $
     openConsumer { x: "foo", z: 42 } == show ["foo"]
@@ -56,3 +70,88 @@ test = do
     openConsumer { x: true, y: false, z: 42 } == show [true, false]
   assert $ -- Make sure explicitly wrapping the field in `Req` also works
     openConsumer { x: Req 5, z: 42 } == show [5]
+  assert $
+    nestedOpenConsumer 42 == show [42, 42]
+
+  assert $
+    monoConsumer { x: 42, z: 42 } == show [42]
+  assert $
+    monoConsumer { x: 42, y: 5, z: 42 } == show [42, 5]
+  assert $
+    monoAmbiguousConsumer { x: Just 42, z: 42 } == show [Just 42]
+  assert $
+    monoAmbiguousConsumer { x: Just 42, y: Just 5, z: 42 } == show [Just 42, Just 5]
+  assert $
+    monoAmbiguousConsumer { x: Nothing, y: Just 5, z: 42 } == show [Nothing, Just 5]
+  assert $
+    monoAmbiguousConsumer { x: Just 42, y: Nothing, z: 42 } == show [Just 42, Nothing]
+
+-- This test explicitly enumerates all coercion use cases that we want to
+-- support. If instance resolution breaks, one or more lines in this function
+-- will fail to compile.
+compileTimeTestClosed :: Identity Unit
+compileTimeTestClosed = do
+  witness (Proxy :: _ Int) (Proxy :: _ Int)
+  witness (Proxy :: _ (Req Int)) (Proxy :: _ Int)
+  witness (Proxy :: _ (Opt Int)) (Proxy :: _ Int)
+  witness (Proxy :: _ (Opt Int)) (Proxy :: _ (Opt Int))
+  witness (Proxy :: _ (Opt (Maybe Int))) (Proxy :: _ (Maybe Int))
+  witness (Proxy :: _ (Opt (Maybe Int))) (Proxy :: _ (Opt (Maybe Int)))
+  genericWitness (Proxy :: _ Int)
+  witness (Proxy :: _ { x :: Req Int, y :: Opt Int }) (Proxy :: _ { x :: Int, y :: Int })
+  where
+    -- This function doesn't do anything at runtime, its whole purpose is to
+    -- make sure an instance of `Closed.Coerce` can be resolved for the types
+    -- that we want to support.
+    witness :: forall expected given. Closed.Coerce given expected => Proxy expected -> Proxy given -> Identity Unit
+    witness _ _ = pure unit
+
+    -- The case where the use site itself is generic (i.e. "forall a") is not
+    -- exactly the same as non-generic case. Class instance resolution works a
+    -- little differently when some type variables are unkown.
+    genericWitness :: forall a. Proxy a -> Identity Unit
+    genericWitness _ = do
+      witness (Proxy :: _ (Req a)) (Proxy :: _ a)
+      witness (Proxy :: _ (Opt a)) (Proxy :: _ (Opt a))
+      witness (Proxy :: _ (Opt (Maybe a))) (Proxy :: _ (Opt (Maybe a)))
+
+      -- DOESN'T COMPILE: witness (Proxy :: _ (Opt a)) (Proxy :: _ a)
+      -- ^ This case isn't supported. We cannot add a case for matching `a` with
+      -- `Opt a` for a generic `a`, because it breaks use cases where the args
+      -- are monomorphic, but the use site passes values of ambiguous types. For
+      -- example:
+      --
+      --       args definition: type Args = { x :: Opt (Maybe Int) }
+      --       use site:        f { x: Nothing }
+      --
+      -- This would require matching expected type `Opt (Maybe Int)` with given
+      -- type `Maybe t1` (the type of `Nothing`), and an instance `Coerce a (Opt
+      -- a)` would be considered "partially overlapping", because it may or may
+      -- not match depending on the choice of `t1`.
+
+      -- DOESN'T COMPILE: witness (Proxy :: _ { x :: Req a, y :: Opt a }) (Proxy :: _ { x :: a, y :: a })
+      -- ^ This case doesn't work due to https://github.com/purescript/purescript/issues/4338
+
+-- See comments on `compileTimeTestClosed`
+compileTimeTestOpen :: Identity Unit
+compileTimeTestOpen = do
+  witness (Proxy :: _ Int) (Proxy :: _ Int)
+  witness (Proxy :: _ (Req Int)) (Proxy :: _ Int)
+  witness (Proxy :: _ (Opt Int)) (Proxy :: _ Int)
+  witness (Proxy :: _ (Opt Int)) (Proxy :: _ (Opt Int))
+  witness (Proxy :: _ (Opt (Maybe Int))) (Proxy :: _ (Maybe Int))
+  witness (Proxy :: _ (Opt (Maybe Int))) (Proxy :: _ (Opt (Maybe Int)))
+  genericWitness (Proxy :: _ Int)
+  witness (Proxy :: _ { x :: Req Int, y :: Opt Int }) (Proxy :: _ { x :: Int, y :: Int })
+  where
+    witness :: forall expected given. Open.Coerce given expected => Proxy expected -> Proxy given -> Identity Unit
+    witness _ _ = pure unit
+
+    genericWitness :: forall a. Proxy a -> Identity Unit
+    genericWitness _ = do
+      witness (Proxy :: _ (Req a)) (Proxy :: _ a)
+      witness (Proxy :: _ (Opt a)) (Proxy :: _ (Opt a))
+      witness (Proxy :: _ (Opt (Maybe a))) (Proxy :: _ (Opt (Maybe a)))
+
+      -- DOESN'T COMPILE: witness (Proxy :: _ (Opt a)) (Proxy :: _ a)
+      -- DOESN'T COMPILE: witness (Proxy :: _ { x :: Req a, y :: Opt a }) (Proxy :: _ { x :: a, y :: a })


### PR DESCRIPTION
To my eternal shame, it turns out that in #16, while adding support for polymorphic values, I broke support for monomorphic ones.

More specifically, this no longer compiles:

```haskell
type Args = { x :: Opt (Maybe Int) }

f :: forall args. Coerce args Args => args -> Int
f _ = 42

x = f { x: Nothing }
```

This breaks, because the type of `x` at use site is ambiguous - `Maybe t1`, so the compiler tries to resolve `Coerce (Maybe t1) (Opt (Maybe Int))`, and this partially overlaps instance `Coerce a (Opt a)`. 

And this makes sense: whether or not `Coerce a (Opt a)` matches `Coerce (Maybe t1) (Opt (Maybe Int))` depends on the choice of `t1`: if `t1 ~ Int`, then it matches, otherwise it does not. 

The only way around this that I can see is to remove the instance entirely. This, of course, breaks a polymorphic use case like this:

```haskell
type Args a = { x :: Opt a }

f :: forall args a. Coerce args (Args a) => args -> Int
f _ = 42

g :: forall a. a -> Int
g a = f { x: a }  -- No instance found for `Coerce a1 (Opt a2)`. Instance `Coerce (Opt a) (Opt a)` partially overlaps
```

I don't see a way to make this work, but there is a workaround: instead of just `a`, pass an `Opt a`:

```haskell
g :: forall a. a -> Int
g a = f { x: opt a }  -- Works now
```

I think it's ok to burden generic consumers with this requirement.